### PR TITLE
Config map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	go.etcd.io/bbolt v1.3.2 // indirect
 	golang.org/x/lint v0.0.0-20190409202823-959b441ac422
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	google.golang.org/appengine v1.5.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.42.0 // indirect
 	k8s.io/api v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -560,6 +560,7 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mvdan/xurls v1.1.0/go.mod h1:tQlNn3BED8bE/15hnSL2HLkDeLWpNPAwtw7wkEq44oU=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.1/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=

--- a/pkg/plndrcp/disabledServices.go
+++ b/pkg/plndrcp/disabledServices.go
@@ -1,0 +1,44 @@
+package plndrcp
+
+import cloudprovider "k8s.io/cloud-provider"
+
+// Instances returns an instances interface. Also returns true if the interface is supported, false otherwise.
+func (p *PlunderCloudProvider) Instances() (cloudprovider.Instances, bool) {
+	return nil, false
+}
+
+// Zones returns a zones interface. Also returns true if the interface is supported, false otherwise.
+func (p *PlunderCloudProvider) Zones() (cloudprovider.Zones, bool) {
+	return nil, true
+}
+
+// Clusters returns a clusters interface.  Also returns true if the interface is supported, false otherwise.
+func (p *PlunderCloudProvider) Clusters() (cloudprovider.Clusters, bool) {
+	return nil, false
+}
+
+// Routes returns a routes interface along with whether the interface is supported.
+func (p *PlunderCloudProvider) Routes() (cloudprovider.Routes, bool) {
+	return nil, false
+}
+
+// ProviderName returns the cloud provider ID.
+func (p *PlunderCloudProvider) ProviderName() string {
+	return "plunder"
+}
+
+// ScrubDNS provides an opportunity for cloud-provider-specific code to process DNS settings for pods.
+func (p *PlunderCloudProvider) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nil, nil
+}
+
+// HasClusterID provides an opportunity for cloud-provider-specific code to process DNS settings for pods.
+func (p *PlunderCloudProvider) HasClusterID() bool {
+	return false
+}
+
+type zones struct{}
+
+func (z zones) GetZone() (cloudprovider.Zone, error) {
+	return cloudprovider.Zone{FailureDomain: "FailureDomain1", Region: "Region1"}, nil
+}

--- a/pkg/plndrcp/loadBalancer.go
+++ b/pkg/plndrcp/loadBalancer.go
@@ -2,63 +2,138 @@ package plndrcp
 
 import (
 	"context"
+	"encoding/json"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type plndrServices struct {
+	Services []services `json:"services"`
+}
+
+type services struct {
+	Vip         string `json:"vip"`
+	UID         string `json:"uid:`
+	ServiceName string `json:"serviceName"`
+}
+
 //PlndrLoadBalancer -
-type plndrLoadBalancer struct {
+type plndrLoadBalancerManager struct {
 	kubeClient  *kubernetes.Clientset
 	namespace   string
-	name        string
+	configMap   string
 	serviceCidr string
 }
 
-func newLoadBalancer(kubeClient *kubernetes.Clientset, ns, name, serviceCidr string) cloudprovider.LoadBalancer {
-	return &plndrLoadBalancer{
+func newLoadBalancer(kubeClient *kubernetes.Clientset, ns, cm, serviceCidr string) cloudprovider.LoadBalancer {
+	return &plndrLoadBalancerManager{
 		kubeClient:  kubeClient,
 		namespace:   ns,
-		name:        name,
+		configMap:   cm,
 		serviceCidr: serviceCidr}
 }
 
-func (plb *plndrLoadBalancer) EnsureLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (lbs *v1.LoadBalancerStatus, err error) {
+func (plb *plndrLoadBalancerManager) EnsureLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (lbs *v1.LoadBalancerStatus, err error) {
 	return plb.syncLoadBalancer(service)
 }
-func (plb *plndrLoadBalancer) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (err error) {
+func (plb *plndrLoadBalancerManager) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (err error) {
+	_, err = plb.syncLoadBalancer(service)
 	return err
 }
 
-func (plb *plndrLoadBalancer) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
+func (plb *plndrLoadBalancerManager) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
+	klog.Infof("Deleting service '%s' (%s)", service.Name, service.UID)
+
 	return plb.deleteLoadBalancer(service)
 }
 
-func (plb *plndrLoadBalancer) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
+func (plb *plndrLoadBalancerManager) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
 	return nil, false, nil
 }
 
 // GetLoadBalancerName returns the name of the load balancer. Implementations must treat the
 // *v1.Service parameter as read-only and not modify it.
-func (plb *plndrLoadBalancer) GetLoadBalancerName(_ context.Context, clusterName string, service *v1.Service) string {
+func (plb *plndrLoadBalancerManager) GetLoadBalancerName(_ context.Context, clusterName string, service *v1.Service) string {
 	return getDefaultLoadBalancerName(service)
 }
 
 func getDefaultLoadBalancerName(service *v1.Service) string {
 	return cloudprovider.DefaultLoadBalancerName(service)
 }
-func (plb *plndrLoadBalancer) deleteLoadBalancer(service *v1.Service) error {
+func (plb *plndrLoadBalancerManager) deleteLoadBalancer(service *v1.Service) error {
 
 	return nil
 }
 
-func (plb *plndrLoadBalancer) syncLoadBalancer(service *v1.Service) (*v1.LoadBalancerStatus, error) {
+func (plb *plndrLoadBalancerManager) syncLoadBalancer(service *v1.Service) (*v1.LoadBalancerStatus, error) {
+	var vip string
+	vip = "192.168.0.76"
+	// This function reconciles the load balancer state
+	klog.Infof("syncing service '%s' (%s) with vip: %s", service.Name, service.UID, vip)
+	//	return nil, fmt.Errorf("BOOM, no kube-vip for you ..")
 
-	return nil, nil
+	cm, err := plb.kubeClient.CoreV1().ConfigMaps(plb.namespace).Get(plb.configMap, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Can't find config Map %s, creating new Map", plb.configMap)
+		cm := v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      plb.configMap,
+				Namespace: plb.namespace,
+			},
+		}
+		_, err = plb.kubeClient.CoreV1().ConfigMaps(plb.namespace).Create(&cm)
+		if err != nil {
+			klog.Errorf("%v", err)
+		}
+	}
+	var svc plndrServices
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+		cm.Data["services"] = svc.updateServices(vip, service.Name, string(service.UID))
+
+	} else {
+		b := cm.Data["services"]
+		json.Unmarshal([]byte(b), &svc)
+		cm.Data["services"] = svc.updateServices(vip, service.Name, string(service.UID))
+	}
+
+	if cm.Annotations == nil {
+		cm.Annotations = map[string]string{}
+	}
+
+	_, err = plb.kubeClient.CoreV1().ConfigMaps(plb.namespace).Update(cm)
+
+	if err != nil {
+		klog.Errorf("%v", err)
+	}
+
+	return &v1.LoadBalancerStatus{
+		Ingress: []v1.LoadBalancerIngress{
+			{
+				IP: vip,
+			},
+		},
+	}, nil
 }
 
-func (plb *plndrLoadBalancer) getConfigMap() (*v1.ConfigMap, error) {
-
-	return nil, nil
+func (s *plndrServices) updateServices(vip, name, uid string) string {
+	newsvc := services{
+		Vip:         vip,
+		UID:         uid,
+		ServiceName: name,
+	}
+	s.Services = append(s.Services, newsvc)
+	b, _ := json.Marshal(s)
+	return string(b)
 }
+
+// func (plb *plndrLoadBalancerManager) getConfigMap() (*v1.ConfigMap, error) {
+
+// 	return nil, nil
+// }


### PR DESCRIPTION
[`WIP`] - but the cloud-provider now creates the required configMaps for the `kube-vip` pods.