### PR TITLE
Outside cluster flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ func main() {
 
 	command := app.NewCloudControllerManagerCommand()
 
+	command.Flags().BoolVar(&plndrcp.OutSideCluster, "OutSideCluster", false, "Start Controller outside of cluster")
+
 	// Set static flags for which we know the values.
 	command.Flags().VisitAll(func(fl *pflag.Flag) {
 		var err error


### PR DESCRIPTION
The flag `--OutSideCluster` allows starting the controller using a kubeConfig file instead of attempting to use local service token.