### PR TITLE
Cidr is now stored in the configMap

### DIFF
--- a/pkg/plndrcp/config.go
+++ b/pkg/plndrcp/config.go
@@ -82,6 +82,9 @@ func (plb *plndrLoadBalancerManager) UpdateConfigMap(cm *v1.ConfigMap, s *plndrS
 	b, _ := json.Marshal(s)
 	cm.Data[PlunderServicesKey] = string(b)
 
+	// TODO - in this first release the CIDR will be static
+	cm.Data["cidr"] = plb.serviceCidr
+
 	// Return results of configMap create
 	return plb.kubeClient.CoreV1().ConfigMaps(plb.namespace).Update(cm)
 }

--- a/pkg/plndrcp/loadBalancer.go
+++ b/pkg/plndrcp/loadBalancer.go
@@ -102,7 +102,9 @@ func (plb *plndrLoadBalancerManager) deleteLoadBalancer(service *v1.Service) err
 
 	// Update the services configuration, by removing the  service
 	updatedSvc := svc.delServiceFromUID(string(service.UID))
-	ipam.ReleaseAddress(service.Status.LoadBalancer.Ingress[0].IP)
+	if len(service.Status.LoadBalancer.Ingress) != 0 {
+		ipam.ReleaseAddress(service.Status.LoadBalancer.Ingress[0].IP)
+	}
 	// Update the configMap
 	_, err = plb.UpdateConfigMap(cm, updatedSvc)
 	return err
@@ -141,7 +143,7 @@ func (plb *plndrLoadBalancerManager) syncLoadBalancer(service *v1.Service) (*v1.
 		ServiceName: service.Name,
 		UID:         string(service.UID),
 		Vip:         vip,
-		Port:        service.Spec.Ports[0].TargetPort.IntValue(),
+		Port:        int(service.Spec.Ports[0].Port),
 	}
 
 	svc.addService(newSvc)


### PR DESCRIPTION
The CIDR is now stored within the configMap, this means that the starboard daemonset will be able to `watch()` this configMap and ensure that a hosts `iptables` behave as expected.