### PR TITLE
Strip out configuration

### DIFF
--- a/example/pod/0.1.2.yaml
+++ b/example/pod/0.1.2.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: plunder-cloud-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:plunder-cloud-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "endpoints","events","services/status"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["nodes", "services"]
+    verbs: ["list","get","watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:plunder-cloud-controller-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:plunder-cloud-controller-role
+subjects:
+- kind: ServiceAccount
+  name: plunder-cloud-controller
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  name: plndr-cloud-provider
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - /plndr-cloud-provider
+    image: plndr/plndr-cloud-provider:0.1.2
+    name: plndr-cloud-provider
+    imagePullPolicy: Always
+    resources: {}
+  serviceAccountName: plunder-cloud-controller

--- a/main.go
+++ b/main.go
@@ -41,7 +41,6 @@ func main() {
 	command := app.NewCloudControllerManagerCommand()
 
 	command.Flags().BoolVar(&plndrcp.OutSideCluster, "OutSideCluster", false, "Start Controller outside of cluster")
-	command.Flags().StringVar(&plndrcp.CIDR, "cidr", "", "Virtual IP Address range (192.168.0.70/30)")
 
 	// Set static flags for which we know the values.
 	command.Flags().VisitAll(func(fl *pflag.Flag) {

--- a/pkg/plndrcp/config.go
+++ b/pkg/plndrcp/config.go
@@ -47,21 +47,21 @@ func (plb *plndrLoadBalancerManager) GetServices(cm *v1.ConfigMap) (svcs *plndrS
 	return
 }
 
-func (plb *plndrLoadBalancerManager) GetConfigMap(nm string) (*v1.ConfigMap, error) {
+func (plb *plndrLoadBalancerManager) GetConfigMap(cm, nm string) (*v1.ConfigMap, error) {
 	// Attempt to retrieve the config map
-	return plb.kubeClient.CoreV1().ConfigMaps(nm).Get(plb.configMap, metav1.GetOptions{})
+	return plb.kubeClient.CoreV1().ConfigMaps(nm).Get(plb.cloudConfigMap, metav1.GetOptions{})
 }
 
-func (plb *plndrLoadBalancerManager) CreateConfigMap(nm string) (*v1.ConfigMap, error) {
+func (plb *plndrLoadBalancerManager) CreateConfigMap(cm, nm string) (*v1.ConfigMap, error) {
 	// Create new configuration map in the correct namespace
-	cm := v1.ConfigMap{
+	newConfigMap := v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      plb.configMap,
+			Name:      plb.cloudConfigMap,
 			Namespace: nm,
 		},
 	}
 	// Return results of configMap create
-	return plb.kubeClient.CoreV1().ConfigMaps(nm).Create(&cm)
+	return plb.kubeClient.CoreV1().ConfigMaps(nm).Create(&newConfigMap)
 }
 
 func (plb *plndrLoadBalancerManager) UpdateConfigMap(cm *v1.ConfigMap, s *plndrServices) (*v1.ConfigMap, error) {

--- a/pkg/plndrcp/provider.go
+++ b/pkg/plndrcp/provider.go
@@ -18,15 +18,15 @@ import (
 // OutSideCluster allows the controller to be started using a local kubeConfig for testing
 var OutSideCluster bool
 
-// CIDR specifies the address range for Virtual IP addresses
-var CIDR string
-
 const (
 	//ProviderName is the name of the cloud provider
 	ProviderName = "plndr"
 
-	//PlunderConfigMap is the default name of the load balancer config Map
-	PlunderConfigMap = "plndr-configmap"
+	//PlunderCloudConfig is the default name of the load balancer config Map
+	PlunderCloudConfig = "plndr"
+
+	//PlunderClientConfig is the default name of the load balancer config Map
+	PlunderClientConfig = "plndr"
 
 	//PlunderServicesKey is the key in the ConfigMap that has the services configuration
 	PlunderServicesKey = "plndr-services"
@@ -49,15 +49,11 @@ func newPlunderCloudProvider(io.Reader) (cloudprovider.Interface, error) {
 	cidr := os.Getenv("PLNDR_SERVICE_CIDR")
 
 	if cm == "" {
-		cm = PlunderConfigMap
+		cm = PlunderCloudConfig
 	}
 
 	if ns == "" {
 		ns = "default"
-	}
-
-	if cidr == "" {
-		cidr = CIDR
 	}
 
 	var cl *kubernetes.Clientset


### PR DESCRIPTION
This tidies out the separation of the `kube-system` configmap and the configuration maps that exist in other namespaces for load-balancing.