### PR TITLE
fix syncLoadbalancer by re-using existing VIP

### DIFF
--- a/pkg/plndrcp/config.go
+++ b/pkg/plndrcp/config.go
@@ -13,6 +13,15 @@ func (s *plndrServices) addService(newSvc services) {
 	s.Services = append(s.Services, newSvc)
 }
 
+func (s *plndrServices) findService(UID string) *services {
+	for x := range s.Services {
+		if s.Services[x].UID == UID {
+			return &s.Services[x]
+		}
+	}
+	return nil
+}
+
 func (s *plndrServices) delServiceFromUID(UID string) *plndrServices {
 	// New Services list
 	updatedServices := &plndrServices{}


### PR DESCRIPTION
fix for https://github.com/plunder-app/kube-vip/issues/51

Untested, but this looks like the correct approach

What I think is happening is when the plndr-cloud-provider pod restarts it always creates a new VIP entry, this fix looks up an existsing VIP for the service UUID and returns that