### PR TITLE
Adding the github actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,43 @@
+name: Publish the latest dev image
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare Names
+        id: prep
+        run: |
+          DOCKER_IMAGE=plndr/plndr-cloud-provider
+          VERSION=$(echo ${GITHUB_SHA} | cut -c1-8)
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          TAGS="$TAGS,${DOCKER_IMAGE}:nightly"
+          echo ::set-output name=tags::${TAGS}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push main branch 
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+name: Publish Releases to Docker Hub
+
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare Names
+        id: prep
+        run: |
+          DOCKER_IMAGE=plndr/plndr-cloud-provider
+          VERSION=${GITHUB_REF#refs/tags/}
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          TAGS="$TAGS,${DOCKER_IMAGE}:latest"
+          echo ::set-output name=tags::${TAGS}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push main branch 
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Hello,

I needed to build the plndr-cloud-provider for arm64, so I also automated it with github actions. 
For this PR to work, 2 secrets have to be set up (https://www.edwardthomson.com/blog/github_actions_11_secrets.html):

* DOCKERHUB_USERNAME and
* DOCKERHUB_TOKEN (which can be generated from docker hub -- https://docs.docker.com/docker-hub/access-tokens/#create-an-access-token)

It will publish all the commits in the master branch under the nightly tag (and the commit hash),
and the (git) tags will be also be published under the name of the tag and the latest tag (see my repo for details -- https://hub.docker.com/r/anagno/plndr-cloud-provider/tags)

Probably it also resolves https://github.com/plunder-app/plndr-cloud-provider/issues/31

I hope it is usefull.

KR,
Vasileios